### PR TITLE
use import instead of require

### DIFF
--- a/resources/js/wishlist.js
+++ b/resources/js/wishlist.js
@@ -1,4 +1,4 @@
-Vue.component('wishlist', require('Vendor/rapidez/wishlist/resources/js/Wishlist.vue').default)
+Vue.component('wishlist', () => import('Vendor/rapidez/wishlist/resources/js/Wishlist.vue'))
 
 document.addEventListener('turbolinks:load', () => {
     window.app.$on('logged-in', async () => {

--- a/resources/js/wishlist.js
+++ b/resources/js/wishlist.js
@@ -1,4 +1,5 @@
-Vue.component('wishlist', () => import('Vendor/rapidez/wishlist/resources/js/Wishlist.vue'))
+import wishlist from 'Vendor/rapidez/wishlist/resources/js/Wishlist.vue'
+Vue.component('wishlist', wishlist)
 
 document.addEventListener('turbolinks:load', () => {
     window.app.$on('logged-in', async () => {


### PR DESCRIPTION
Both Webpack and Vite support import functions, so this is a backwards compatible change